### PR TITLE
docs: clean up documentation and remove premature references

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@
 ## 📞 Support
 
 - 🐛 [Bug Reports](https://github.com/capiscio/capiscio-cli/issues)
-- 💬 [Discussions](https://github.com/capiscio/capiscio-cli/discussions)
-- 📖 [Documentation](https://capiscio.dev/cli)
-- 🔒 [Security Policy](SECURITY.md)
+- � [Security Policy](SECURITY.md)
+- � [Security Issues](mailto:security@capiscio.dev)
 
 ## 📚 Documentation
 
@@ -17,7 +16,9 @@
 - **[API Reference](docs/api-reference.md)** - Programmatic usage documentation
 - **[Architecture](docs/architecture.md)** - Internal design and extensibility
 - **[Changelog](CHANGELOG.md)** - Version history and release notes
-- **[Contributing](CONTRIBUTING.md)** - Development and contribution guidepeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org/)
+- **[Contributing](CONTRIBUTING.md)** - Development and contribution guide
+
+[![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org/)
 
 ## 🚀 Quick Start
 
@@ -380,9 +381,8 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 ## 📞 Support
 
 - 🐛 [Bug Reports](https://github.com/capiscio/capiscio-cli/issues)
-- 💬 [Discussions](https://github.com/capiscio/capiscio-cli/discussions)
-- 📖 [Documentation](https://capisc.io/cli)
+- � [Security Issues](mailto:security@capiscio.dev)
 
 ---
 
-Built with ❤️ by the [Capiscio](https://capisc.io) team.
+Built with ❤️ by the [Capiscio](https://github.com/capiscio) team.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,145 @@
-# Security Policy\n\n## Supported Versions\n\nWe provide security updates for the following versions of Capiscio CLI:\n\n| Version | Supported          |\n| ------- | ------------------ |\n| 1.x.x   | :white_check_mark: |\n\n## Reporting a Vulnerability\n\nWe take the security of Capiscio CLI seriously. If you believe you have found a security vulnerability, please report it to us as described below.\n\n### How to Report\n\n**Please do not report security vulnerabilities through public GitHub issues.**\n\nInstead, please report them via email to: security@capiscio.dev\n\nYou should receive a response within 48 hours. If for some reason you do not, please follow up via email to ensure we received your original message.\n\n### What to Include\n\nPlease include the following information in your report:\n\n- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)\n- Full paths of source file(s) related to the manifestation of the issue\n- The location of the affected source code (tag/branch/commit or direct URL)\n- Any special configuration required to reproduce the issue\n- Step-by-step instructions to reproduce the issue\n- Proof-of-concept or exploit code (if possible)\n- Impact of the issue, including how an attacker might exploit the issue\n\n### Security Considerations\n\nCapiscio CLI is designed with security in mind:\n\n#### Network Security\n- Uses HTTPS by default for all remote requests\n- Implements proper timeout handling to prevent hanging connections\n- Does not store or cache sensitive information\n- Uses standard HTTP headers and follows security best practices\n\n#### Input Validation\n- All JSON input is parsed safely\n- URL validation prevents malicious redirects\n- File path validation prevents directory traversal attacks\n- Input sanitization for all user-provided data\n\n#### Dependencies\n- Minimal dependency footprint to reduce attack surface\n- Regular dependency auditing and updates\n- No external service dependencies that could be compromised\n\n#### Data Handling\n- No persistent storage of validated agent cards\n- No transmission of sensitive data to external services\n- All validation is performed locally\n\n## Vulnerability Response\n\nWhen we receive a security bug report, we will:\n\n1. **Acknowledge** receipt of your report within 48 hours\n2. **Assess** the vulnerability and determine its impact\n3. **Develop** a fix for the issue\n4. **Test** the fix thoroughly\n5. **Release** a patch version as soon as possible\n6. **Notify** the community about the security update\n\n### Timeline\n\n- **Critical vulnerabilities**: Patch within 7 days\n- **High vulnerabilities**: Patch within 14 days\n- **Medium/Low vulnerabilities**: Patch in next regular release\n\n### Credit\n\nWe believe in giving credit to security researchers who help make our software safer. If you report a security vulnerability, we will:\n\n- Credit you in the security advisory (unless you prefer to remain anonymous)\n- Include your name in the CHANGELOG for the release that fixes the issue\n- Provide a brief description of your contribution\n\n## Security Best Practices for Users\n\n### When Using Capiscio CLI\n\n1. **Keep Updated**: Always use the latest version of Capiscio CLI\n2. **Verify Sources**: Only validate agent cards from trusted sources\n3. **Network Security**: Be cautious when validating URLs from untrusted sources\n4. **File Permissions**: Ensure proper file permissions on agent card files\n5. **CI/CD Security**: Use JSON output mode in automated environments\n\n### In Production Environments\n\n1. **Use Strict Mode**: Enable strict validation for production deployments\n2. **Network Isolation**: Consider running validation in isolated environments\n3. **Logging**: Monitor validation logs for suspicious activity\n4. **Access Control**: Limit who can run validation commands in production\n\n### For Developers\n\n1. **Validate Input**: Always validate agent cards before deployment\n2. **Use HTTPS**: Ensure agent cards are served over HTTPS\n3. **Content Security**: Implement proper Content-Security-Policy headers\n4. **Regular Audits**: Regularly audit your agent card configurations\n\n## Scope\n\nThis security policy applies to:\n\n- The Capiscio CLI codebase\n- npm package distribution\n- GitHub repository and releases\n- Documentation and examples\n\nThis policy does not cover:\n\n- Third-party agent cards validated by the CLI\n- External services that agent cards may reference\n- User-specific configurations or environments\n\n## Contact\n\nFor general security questions (not vulnerability reports), please contact:\nsecurity@capiscio.dev\n\nFor urgent security matters, you may also reach out via:\n- GitHub Security Advisory (for confirmed vulnerabilities)\n- Direct message to maintainers (for clarification only)\n\n## Legal\n\nBy reporting security vulnerabilities, you agree that:\n\n- You will not access, modify, or delete data belonging to others\n- You will not perform any attacks that could harm the reliability or integrity of our services\n- You will not disclose the vulnerability publicly until we have had time to address it\n- Your testing and research comply with applicable laws\n\n---\n\nThank you for helping keep Capiscio CLI and our users safe!\n
+# Security Policy
+
+## Supported Versions
+
+We provide security updates for the following versions of Capiscio CLI:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+We take the security of Capiscio CLI seriously. If you believe you have found a security vulnerability, please report it to us as described below.
+
+### How to Report
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via email to: security@capiscio.dev
+
+You should receive a response within 48 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
+
+### What to Include
+
+Please include the following information in your report:
+
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
+
+### Security Considerations
+
+Capiscio CLI is designed with security in mind:
+
+#### Network Security
+- Uses HTTPS by default for all remote requests
+- Implements proper timeout handling to prevent hanging connections
+- Does not store or cache sensitive information
+- Uses standard HTTP headers and follows security best practices
+
+#### Input Validation
+- All JSON input is parsed safely
+- URL validation prevents malicious redirects
+- File path validation prevents directory traversal attacks
+- Input sanitization for all user-provided data
+
+#### Dependencies
+- Minimal dependency footprint to reduce attack surface
+- Regular dependency auditing and updates
+- No external service dependencies that could be compromised
+
+#### Data Handling
+- No persistent storage of validated agent cards
+- No transmission of sensitive data to external services
+- All validation is performed locally
+
+## Vulnerability Response
+
+When we receive a security bug report, we will:
+
+1. **Acknowledge** receipt of your report within 48 hours
+2. **Assess** the vulnerability and determine its impact
+3. **Develop** a fix for the issue
+4. **Test** the fix thoroughly
+5. **Release** a patch version as soon as possible
+6. **Notify** the community about the security update
+
+### Timeline
+
+- **Critical vulnerabilities**: Patch within 7 days
+- **High vulnerabilities**: Patch within 14 days
+- **Medium/Low vulnerabilities**: Patch in next regular release
+
+### Credit
+
+We believe in giving credit to security researchers who help make our software safer. If you report a security vulnerability, we will:
+
+- Credit you in the security advisory (unless you prefer to remain anonymous)
+- Include your name in the CHANGELOG for the release that fixes the issue
+- Provide a brief description of your contribution
+
+## Security Best Practices for Users
+
+### When Using Capiscio CLI
+
+1. **Keep Updated**: Always use the latest version of Capiscio CLI
+2. **Verify Sources**: Only validate agent cards from trusted sources
+3. **Network Security**: Be cautious when validating URLs from untrusted sources
+4. **File Permissions**: Ensure proper file permissions on agent card files
+5. **CI/CD Security**: Use JSON output mode in automated environments
+
+### In Production Environments
+
+1. **Use Strict Mode**: Enable strict validation for production deployments
+2. **Network Isolation**: Consider running validation in isolated environments
+3. **Logging**: Monitor validation logs for suspicious activity
+4. **Access Control**: Limit who can run validation commands in production
+
+### For Developers
+
+1. **Validate Input**: Always validate agent cards before deployment
+2. **Use HTTPS**: Ensure agent cards are served over HTTPS
+3. **Content Security**: Implement proper Content-Security-Policy headers
+4. **Regular Audits**: Regularly audit your agent card configurations
+
+## Scope
+
+This security policy applies to:
+
+- The Capiscio CLI codebase
+- npm package distribution
+- GitHub repository and releases
+- Documentation and examples
+
+This policy does not cover:
+
+- Third-party agent cards validated by the CLI
+- External services that agent cards may reference
+- User-specific configurations or environments
+
+## Contact
+
+For general security questions (not vulnerability reports), please contact:
+security@capiscio.dev
+
+For urgent security matters, you may also reach out via:
+- GitHub Security Advisory (for confirmed vulnerabilities)
+- Direct message to maintainers (for clarification only)
+
+## Legal
+
+By reporting security vulnerabilities, you agree that:
+
+- You will not access, modify, or delete data belonging to others
+- You will not perform any attacks that could harm the reliability or integrity of our services
+- You will not disclose the vulnerability publicly until we have had time to address it
+- Your testing and research comply with applicable laws
+
+---
+
+Thank you for helping keep Capiscio CLI and our users safe!\n

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "llm",
     "agent-to-agent"
   ],
-  "homepage": "https://capisc.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/capiscio/capiscio-cli.git"


### PR DESCRIPTION
- Remove GitHub Discussions references from README support sections
- Remove capisc.io website links (site not yet live)
- Fix corrupted SECURITY.md file formatting (escaped newlines)
- Remove homepage field from package.json
- Update support channels to focus on GitHub Issues and email

This ensures documentation accurately reflects current project state and removes broken/premature links that could confuse users.