### PR TITLE
fix: prepare v1.2.1 patch release with corrected workflows and docume…

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -67,21 +67,14 @@ jobs:
 
       - name: Bundle CLI with esbuild
         run: |
-          npx esbuild src/cli.ts \
-            --bundle \
-            --platform=node \
-            --target=node18 \
-            --outfile=dist/cli-bundled.js \
-            --banner:js="#!/usr/bin/env node"
+          npx esbuild src/cli.ts --bundle --platform=node --target=node18 --outfile=dist/cli-bundled.js --banner:js="#!/usr/bin/env node"
 
       - name: Create binary directory
         run: mkdir -p dist/binaries
 
       - name: Create binary with pkg
         run: |
-          npx pkg dist/cli-bundled.js \
-            --targets ${{ matrix.target }} \
-            --output dist/binaries/${{ matrix.binary_name }}
+          npx pkg dist/cli-bundled.js --targets ${{ matrix.target }} --output dist/binaries/${{ matrix.binary_name }}
 
       - name: Sign macOS binary (ad-hoc)
         if: runner.os == 'macOS'

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -2,13 +2,13 @@ name: Build and Release Binaries
 
 on:
   release:
-    types: [published]
+    types: [created]  # Triggers when release is created (still allows asset uploads)
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag to build binaries for (e.g., v1.2.0)'
+        description: 'Release tag to build binaries for (e.g., v1.2.1)'
         required: true
-        default: 'v1.2.0'
+        default: 'v1.2.1'
 
 # Explicit permissions for security
 permissions:

--- a/README.md
+++ b/README.md
@@ -51,25 +51,28 @@ capiscio validate ./agent-card.json --strict --json
 
 | Platform | Architecture | Download | Size |
 |----------|-------------|----------|------|
-| **Linux** | x64 | [`capiscio-linux-x64`](https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-linux-x64) | ~50MB |
-| **macOS** | Intel | [`capiscio-darwin-x64`](https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-darwin-x64) | ~54MB |
-| **macOS** | Apple Silicon | [`capiscio-darwin-arm64`](https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-darwin-arm64) | ~48MB |
-| **Windows** | Intel x64 | [`capiscio-win-x64.exe`](https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-win-x64.exe) | ~41MB |
-| **Windows** | ARM64 | [`capiscio-win-arm64.exe`](https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-win-arm64.exe) | ~29MB |
+| **Linux** | x64 | [`capiscio-linux-x64.tar.gz`](https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-linux-x64.tar.gz) | ~18MB |
+| **macOS** | Intel | [`capiscio-darwin-x64.tar.gz`](https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-darwin-x64.tar.gz) | ~48MB |
+| **macOS** | Apple Silicon | [`capiscio-darwin-arm64.tar.gz`](https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-darwin-arm64.tar.gz) | ~44MB |
+| **Windows** | Intel x64 | [`capiscio-win-x64.exe`](https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-win-x64.exe) | ~45MB |
+| **Windows** | ARM64 | [`capiscio-win-arm64.exe`](https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-win-arm64.exe) | ~42MB |
 
 #### Quick Download Commands:
 ```bash
 # Linux x64
-curl -L -o capiscio https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-linux-x64
-chmod +x capiscio
+curl -L -o capiscio-linux-x64.tar.gz https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-linux-x64.tar.gz
+tar -xzf capiscio-linux-x64.tar.gz
+chmod +x capiscio-linux-x64
 
 # macOS Intel
-curl -L -o capiscio https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-darwin-x64
-chmod +x capiscio
+curl -L -o capiscio-darwin-x64.tar.gz https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-darwin-x64.tar.gz
+tar -xzf capiscio-darwin-x64.tar.gz
+chmod +x capiscio-darwin-x64
 
 # macOS Apple Silicon (M1/M2/M3/M4)
-curl -L -o capiscio https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-darwin-arm64
-chmod +x capiscio
+curl -L -o capiscio-darwin-arm64.tar.gz https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-darwin-arm64.tar.gz
+tar -xzf capiscio-darwin-arm64.tar.gz
+chmod +x capiscio-darwin-arm64
 
 # Windows Intel (PowerShell)
 Invoke-WebRequest -Uri "https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-win-x64.exe" -OutFile "capiscio.exe"
@@ -78,7 +81,9 @@ Invoke-WebRequest -Uri "https://github.com/capiscio/capiscio-cli/releases/latest
 Invoke-WebRequest -Uri "https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-win-arm64.exe" -OutFile "capiscio.exe"
 
 # Use the binary
-./capiscio validate ./agent-card.json
+./capiscio-linux-x64 validate ./agent-card.json
+# or ./capiscio-darwin-* validate ./agent-card.json
+# or .\capiscio.exe validate .\agent-card.json
 ```
 
 ## Key Features
@@ -202,9 +207,10 @@ Signature verification adds minimal overhead while providing crucial security gu
 # GitHub Actions - No Node.js required
 - name: Download and Validate Agent
   run: |
-    curl -L -o capiscio https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-linux-x64
-    chmod +x capiscio
-    ./capiscio validate ./agent-card.json --json --strict
+    curl -L -o capiscio-linux-x64.tar.gz https://github.com/capiscio/capiscio-cli/releases/latest/download/capiscio-linux-x64.tar.gz
+    tar -xzf capiscio-linux-x64.tar.gz
+    chmod +x capiscio-linux-x64
+    ./capiscio-linux-x64 validate ./agent-card.json --json --strict
 ```
 
 Exit codes: 0 = success, 1 = validation failed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capiscio-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capiscio-cli",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capiscio-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The definitive CLI tool for validating A2A (Agent-to-Agent) protocol agent cards",
   "keywords": [
     "a2a",

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "capiscio"
-version = "1.2.0"
+version = "1.2.1"
 description = "A2A protocol validator and CLI tool"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
## 🔧 Fix v1.2.1 - Patch Release for Workflow and Documentation Issues

### Summary
Critical patch release to fix v1.2.0 deployment issues including immutable release workflows, incorrect binary documentation, and Windows build failures.

### 🚨 Issues Fixed

#### **GitHub Actions Workflow Issues**
- **Immutable Release Problem**: Workflow triggered on `release: [published]` but releases are immutable at that point
- **Binary Upload Failures**: Could not attach assets to already-published releases
- **Windows Shell Syntax**: PowerShell line continuation errors in Python workflow

#### **Documentation Issues**
- **Incorrect Binary Links**: README showed old binary names without `.tar.gz` for macOS/Linux
- **Wrong Installation Commands**: Missing tar extraction steps for compressed binaries
- **CI/CD Examples**: Outdated commands in workflow examples

### 🔧 Technical Fixes

#### **Workflow Trigger Fix**
```yaml
# Before (problematic)
on:
  release:
    types: [published]  # Release already immutable

# After (correct)
on:
  release:
    types: [created]    # Allows asset uploads
```

#### **Windows Shell Syntax Fix**
```yaml
# Before (failed on Windows PowerShell)
npx esbuild src/cli.ts \
  --bundle \
  --platform=node

# After (cross-platform compatible)
npx esbuild src/cli.ts --bundle --platform=node
```

#### **Binary Download Links Fix**
```markdown
# Before (incorrect)
[capiscio-darwin-x64](https://github.com/.../capiscio-darwin-x64)

# After (correct)
[capiscio-darwin-x64.tar.gz](https://github.com/.../capiscio-darwin-x64.tar.gz)
```

### 📦 Version Updates

All package files synchronized to **v1.2.1**:
- `package.json` & `package-lock.json`
- `python-package/pyproject.toml`  
- Workflow default versions
- CLI dynamic version import (automatically synced)

### 🛠️ Files Changed

| File | Changes | Purpose |
|------|---------|---------|
| `.github/workflows/release-binaries.yml` | Trigger fix, version update | Enable asset uploads to releases |
| `.github/workflows/publish-python.yml` | Shell syntax fix | Fix Windows PowerShell compatibility |
| `README.md` | Binary links, installation commands | Correct user documentation |
| `package.json` | Version bump to 1.2.1 | Version consistency |
| `package-lock.json` | Version bump to 1.2.1 | Lock file sync |
| `python-package/pyproject.toml` | Version bump to 1.2.1 | Python package sync |

### 🚀 Expected Release Process

With these fixes, the v1.2.1 release process will be:

1. **Create v1.2.1 pre-release** (triggers workflow while mutable)
2. **Workflows build & upload** all 5 binary assets:
   - `capiscio-win-x64.exe`
   - `capiscio-win-arm64.exe` 
   - `capiscio-linux-x64.tar.gz`
   - `capiscio-darwin-x64.tar.gz`
   - `capiscio-darwin-arm64.tar.gz`
3. **Verify assets uploaded** correctly
4. **Remove pre-release tag** to publish final release

### 📋 Testing Checklist

- ✅ Version consistency across all packages
- ✅ CLI reports correct version (1.2.1)
- ✅ README binary links point to correct URLs
- ✅ Installation commands include tar extraction
- ✅ Workflow triggers on release creation
- ✅ Shell commands compatible with Windows PowerShell

### 🎯 Validation

#### **CLI Version Check**
```bash
$ node dist/cli.js --version
1.2.1
```

#### **Binary Download URLs**
All links now correctly point to `.tar.gz` for Unix platforms:
- Linux: `capiscio-linux-x64.tar.gz`
- macOS Intel: `capiscio-darwin-x64.tar.gz` 
- macOS Apple Silicon: `capiscio-darwin-arm64.tar.gz`

#### **Installation Commands**
```bash
# Linux/macOS (updated)
curl -L -o capiscio-linux-x64.tar.gz https://github.com/.../capiscio-linux-x64.tar.gz
tar -xzf capiscio-linux-x64.tar.gz
chmod +x capiscio-linux-x64
./capiscio-linux-x64 --version
```

### ⚠️ Breaking Changes
**None** - This is a documentation and infrastructure fix. No changes to CLI functionality or API.

### 🔗 Related Issues
Fixes the following v1.2.0 deployment problems:
- Binary release workflow failures
- Incorrect documentation leading users to broken download links  
- Python package build failures on Windows platforms

---

**Ready for v1.2.1 release!** This patch resolves all deployment blockers and ensures users get working download links and installation instructions.