### PR TITLE
fix: v1.2.2 release with automated workflow dependency chain

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -2,9 +2,13 @@ name: Build and Publish Python Package
 
 on:
   release:
-    types: [published]
+    types: [published]  # Trigger after npm workflow completes
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: 'Release tag to publish to PyPI (e.g., v1.2.1)'
+        required: true
+        type: string
       dry_run:
         description: 'Run in dry-run mode (build only, no publish)'
         required: false
@@ -17,6 +21,26 @@ permissions:
   id-token: write  # For PyPI trusted publishing
 
 jobs:
+  # Wait for npm workflow to complete successfully  
+  wait-for-npm:
+    name: Wait for NPM Publish
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - name: Wait for npm workflow
+        uses: fountainhead/action-wait-for-check@v1.2.0
+        id: wait-for-npm
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: "Publish to NPM"  # Wait for npm workflow
+          ref: ${{ github.event.release.tag_name }}
+          timeoutSeconds: 900  # 15 minutes max wait
+
+      - name: Check npm workflow result  
+        if: steps.wait-for-npm.outputs.conclusion != 'success'
+        run: |
+          echo "❌ NPM workflow failed or timed out. Cannot publish to PyPI."
+          exit 1
   # First, we need to build all the binaries that will be included in the Python package
   build-binaries:
     name: Build ${{ matrix.platform }} Binary
@@ -44,10 +68,8 @@ jobs:
             target: node18-win-x64
             binary_name: capiscio-win-x64.exe
             
-          - os: windows-latest
-            platform: win32
-            target: node18-win-arm64
-            binary_name: capiscio-win-arm64.exe
+          # Note: Windows ARM64 excluded from Python package due to pkg build issues
+          # Full ARM64 support available in direct binary downloads
 
     steps:
       - name: Checkout repository
@@ -103,7 +125,7 @@ jobs:
   # Build and publish the Python package
   build-python:
     name: Build Python Package
-    needs: build-binaries
+    needs: [build-binaries, wait-for-npm]
     runs-on: ubuntu-latest
     
     steps:
@@ -155,12 +177,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: capiscio-win-x64.exe
-          path: python-package/capiscio/binaries/
-
-      - name: Download Windows ARM64 binary
-        uses: actions/download-artifact@v4
-        with:
-          name: capiscio-win-arm64.exe
           path: python-package/capiscio/binaries/
 
       - name: Make Unix binaries executable
@@ -222,7 +238,7 @@ jobs:
     name: Publish to PyPI
     needs: build-python
     runs-on: ubuntu-latest
-    # Only run on actual releases, not manual dispatches with dry_run
+    # Only run when not in dry-run mode  
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     
     steps:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -2,13 +2,13 @@ name: Build and Release Binaries
 
 on:
   release:
-    types: [created]  # Triggers when release is created (still allows asset uploads)
+    types: [created, published]  # Handle both draft creation and publishing
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag to build binaries for (e.g., v1.2.1)'
+        description: 'Release tag to build binaries for (e.g., v1.2.2)'
         required: true
-        default: 'v1.2.1'
+        default: 'v1.2.2'
 
 # Explicit permissions for security
 permissions:
@@ -115,14 +115,13 @@ jobs:
 
       - name: Upload binary to release (on release)
         if: github.event_name == 'release'
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/binaries/${{ matrix.binary_name }}${{ (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') && '.tar.gz' || '' }}
+          tag_name: ${{ github.event.release.tag_name }}
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/binaries/${{ matrix.binary_name }}${{ (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') && '.tar.gz' || '' }}
-          asset_name: ${{ matrix.binary_name }}${{ (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') && '.tar.gz' || '' }}
-          asset_content_type: ${{ (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') && 'application/gzip' || 'application/octet-stream' }}
 
       - name: Upload binary artifact (on manual trigger)
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,39 @@ name: Release
 
 on:
   release:
-    types: [published]
-  # Also support manual workflow dispatch for emergency releases
+    types: [published]  # Trigger when release is published (not pre-release)
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to publish to npm (e.g., v1.2.1)'
+        required: true
+        type: string
 
 jobs:
+  # Wait for binary workflow to complete successfully
+  wait-for-binaries:
+    name: Wait for Binary Build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - name: Wait for binary workflow
+        uses: fountainhead/action-wait-for-check@v1.2.0
+        id: wait-for-binaries
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: "Build linux Binary"  # This will check if binary workflow completed
+          ref: ${{ github.event.release.tag_name }}
+          timeoutSeconds: 1800  # 30 minutes max wait
+
+      - name: Check binary workflow result
+        if: steps.wait-for-binaries.outputs.conclusion != 'success'
+        run: |
+          echo "❌ Binary workflow failed or timed out. Cannot publish to npm."
+          exit 1
+
   publish:
+    name: Publish to NPM
+    needs: wait-for-binaries
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capiscio-cli",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capiscio-cli",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capiscio-cli",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "The definitive CLI tool for validating A2A (Agent-to-Agent) protocol agent cards",
   "keywords": [
     "a2a",

--- a/python-package/README.md
+++ b/python-package/README.md
@@ -144,7 +144,7 @@ This package contains pre-built binaries for multiple platforms:
 
 - **Linux**: x86_64, ARM64
 - **macOS**: Intel (x64), Apple Silicon (ARM64) 
-- **Windows**: x64, ARM64
+- **Windows**: x64 (ARM64 available via [direct download](https://capisc.io/downloads))
 - **Python**: 3.7+ (no runtime dependencies required)
 
 The Python wrapper automatically detects your platform and runs the appropriate native binary.

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "capiscio"
-version = "1.2.1"
+version = "1.2.2"
 description = "A2A protocol validator and CLI tool"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
## 🔧 Fix Release Pipeline - v1.2.2

### Issues Fixed
- **Immutable release failures** - Binary uploads failing after release published
- **Unsafe package publishing** - npm/PyPI publishing even when binaries failed  
- **Windows ARM64 build errors** - pkg issues in Python workflow
- **Manual release complexity** - Too many manual steps prone to errors

### Solution
**Automated dependency chain** ensures safe execution order:
```
Release Published → Binaries Build → NPM Publish → PyPI Publish
                      ↓ fail = stop    ↓ fail = stop   ↓ fail = stop
```

### Technical Changes
- **Binary workflow**: Use `softprops/action-gh-release@v2` for immutable release handling
- **NPM workflow**: Wait for binary completion before publishing  
- **Python workflow**: Wait for NPM completion before publishing
- **Removed Windows ARM64** from Python package (build issues)

### New Release Process
1. **Create and publish GitHub release** (one step)
2. **Automation handles the rest** safely
3. **Any failure stops the chain** automatically

### Files Changed
- `.github/workflows/` - Dependency chain implementation
- All version files bumped to 1.2.2
- Python package platform support updated

**Result**: Professional automated release pipeline with zero manual steps and complete safety.