### PR TITLE
feat: prepare v1.2.3 release with simplified workflows

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -2,13 +2,9 @@ name: Build and Publish Python Package
 
 on:
   release:
-    types: [published]  # Trigger after npm workflow completes
+    types: [published]
   workflow_dispatch:
     inputs:
-      release_tag:
-        description: 'Release tag to publish to PyPI (e.g., v1.2.1)'
-        required: true
-        type: string
       dry_run:
         description: 'Run in dry-run mode (build only, no publish)'
         required: false
@@ -21,26 +17,6 @@ permissions:
   id-token: write  # For PyPI trusted publishing
 
 jobs:
-  # Wait for npm workflow to complete successfully  
-  wait-for-npm:
-    name: Wait for NPM Publish
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release'
-    steps:
-      - name: Wait for npm workflow
-        uses: fountainhead/action-wait-for-check@v1.2.0
-        id: wait-for-npm
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: "Publish to NPM"  # Wait for npm workflow
-          ref: ${{ github.event.release.tag_name }}
-          timeoutSeconds: 900  # 15 minutes max wait
-
-      - name: Check npm workflow result  
-        if: steps.wait-for-npm.outputs.conclusion != 'success'
-        run: |
-          echo "❌ NPM workflow failed or timed out. Cannot publish to PyPI."
-          exit 1
   # First, we need to build all the binaries that will be included in the Python package
   build-binaries:
     name: Build ${{ matrix.platform }} Binary
@@ -125,7 +101,7 @@ jobs:
   # Build and publish the Python package
   build-python:
     name: Build Python Package
-    needs: [build-binaries, wait-for-npm]
+    needs: build-binaries
     runs-on: ubuntu-latest
     
     steps:
@@ -238,7 +214,7 @@ jobs:
     name: Publish to PyPI
     needs: build-python
     runs-on: ubuntu-latest
-    # Only run when not in dry-run mode  
+    # Only run on actual releases, not manual dispatches with dry_run
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     
     steps:

--- a/python-package/capiscio/__init__.py
+++ b/python-package/capiscio/__init__.py
@@ -5,6 +5,6 @@ This package provides a Python wrapper around the Capiscio CLI tool,
 allowing easy installation and usage via pip.
 """
 
-__version__ = "1.1.0"
+__version__ = "1.2.3"
 __author__ = "Capiscio Team"
 __email__ = "hello@capiscio.com"

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "capiscio"
-version = "1.2.2"
+version = "1.2.3"
 description = "A2A protocol validator and CLI tool"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
## 🚀 Prepare v1.2.3 Release with Simplified Workflows

### Summary
This PR prepares the v1.2.3 release with version bumps and workflow simplifications that build on our draft-first release process.

### Changes

#### 📦 Version Updates
- **NPM Package**: `1.2.2` → `1.2.3` (package.json, package-lock.json)
- **Python Package**: `1.1.0` → `1.2.3` (pyproject.toml, __init__.py)
- **Version Consistency**: All packages now aligned on v1.2.3

#### 🔧 Workflow Improvements
- **Removed NPM-waiting logic** from Python workflow
- **Parallel publishing**: NPM and Python workflows now run independently on `published`
- **Simplified inputs**: Removed unnecessary `release_tag` parameter from Python workflow
- **Cleaner dependencies**: Python workflow only depends on `build-binaries`, not waiting jobs

#### 🎯 Benefits
- ✅ **Faster releases**: NPM and PyPI publish in parallel instead of sequentially
- ✅ **Simplified logic**: No complex waiting mechanisms that can fail
- ✅ **Version consistency**: All packages properly aligned
- ✅ **Ready for testing**: Draft-first release process with v1.2.3

### Workflow Changes Detail

**Before:**
```yaml
# Python workflow waited for NPM to complete
needs: [build-binaries, wait-for-npm]
```

**After:**
```yaml
# Python workflow runs independently  
needs: build-binaries
```

### Testing Plan
1. Merge this PR
2. Create v1.2.3 as **draft release**
3. Wait for binaries to upload
4. **Publish release** to trigger NPM/PyPI workflows
5. Verify parallel publishing works correctly

### Dependencies
- Builds on #[previous PR] (draft-first release process)
- Ready to test the complete workflow automation

---

**This PR completes our release workflow modernization and prepares v1.2.3 for testing the new draft-first process.**