### PR TITLE
Fix/tag based binary workflow

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,14 +1,15 @@
 name: Build and Release Binaries
 
 on:
-  release:
-    types: [created]  # Only trigger on draft creation - uploads assets before release becomes immutable
+  push:
+    tags:
+      - 'v*'  # Trigger on any version tag push (v1.2.3, v2.0.0, etc.)
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag to build binaries for (e.g., v1.2.1)'
+        description: 'Release tag to build binaries for (e.g., v0.0.1)'
         required: true
-        default: 'v1.2.1'
+        default: 'v0.0.1'
 
 # Explicit permissions for security
 permissions:
@@ -113,12 +114,12 @@ jobs:
           # Remove the original binary since we now have the tarball
           rm ${{ matrix.binary_name }}
 
-      - name: Upload binary to draft release
-        if: github.event_name == 'release'
+      - name: Upload binary to release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           files: dist/binaries/${{ matrix.binary_name }}${{ (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') && '.tar.gz' || '' }}
-          tag_name: ${{ github.event.release.tag_name }}
+          tag_name: ${{ github.ref_name }}
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capiscio-cli",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capiscio-cli",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capiscio-cli",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "The definitive CLI tool for validating A2A (Agent-to-Agent) protocol agent cards",
   "keywords": [
     "a2a",


### PR DESCRIPTION
## 🔧 Fix: Tag-Based Binary Workflow - Final Solution to GitHub Immutability

### Problem
After discovering that GitHub's release events don't trigger workflows for **draft releases** and that **all release types are now immutable**, our previous approach was fundamentally broken.

**GitHub Documentation Findings:**
> "Workflows are not triggered for the created, edited, or deleted activity types for draft releases."
> "Pre-releases can also be immutable" (new GitHub feature)

### Solution
Switched to **tag-based triggers** that completely bypass GitHub's release immutability constraints.

#### 🔄 New Workflow Trigger
```yaml
# Before: Broken for drafts/pre-releases
on:
  release:
    types: [created]  # ❌ Doesn't work for drafts

# After: Works reliably  
on:
  push:
    tags:
      - 'v*'  # ✅ Triggers on any version tag push
```

#### 🎯 New Release Process
1. **Push version tag** (`git push origin v1.2.3`) → Binary workflow triggers immediately
2. **Wait for binaries** to build and upload (~10-15 minutes) 
3. **Create GitHub release** manually → Binaries already attached
4. **Publish release** → NPM and PyPI workflows trigger

### Technical Changes
- **Trigger**: `push: tags: ['v*']` instead of `release: types: [created]`
- **Tag reference**: `github.ref_name` instead of `github.event.release.tag_name`
- **Upload condition**: `startsWith(github.ref, 'refs/tags/')` instead of release event check
- **Version alignment**: All packages updated to v1.2.3

### Benefits
- ✅ **Eliminates immutability issues** - binaries upload before release exists
- ✅ **No coordination complexity** - tag push immediately triggers builds
- ✅ **Works with any release type** - draft, pre-release, or direct publishing
- ✅ **Reliable automation** - no GitHub UI timing dependencies

### Testing Plan
1. Merge this PR
2. Push v1.2.3 tag: `git push origin v1.2.3 --force`  
3. Verify binary workflow triggers and uploads assets
4. Create v1.2.3 GitHub release (binaries will be pre-attached)
5. Publish to test NPM/PyPI workflows

---

**This PR provides the final, definitive solution to our release automation challenges.**