### PR TITLE
chore: bump version to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-03-27
+
+### Changed
+- **CORE VERSION**: Now downloads `capiscio-core` v2.6.0
+
 ## [2.5.0] - 2026-03-16
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capiscio",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capiscio",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capiscio",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "The official CapiscIO CLI tool for validating A2A agents",
   "keywords": [
     "a2a",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@
  * ```
  */
 
-export const version = '2.5.0';
+export const version = '2.6.0';
 
 // Re-export binary manager for advanced users who want to manage the binary
 export { BinaryManager } from './utils/binary-manager';

--- a/src/utils/binary-manager.ts
+++ b/src/utils/binary-manager.ts
@@ -14,7 +14,7 @@ const REPO_OWNER = 'capiscio';
 const REPO_NAME = 'capiscio-core';
 
 // Allow version override via env var or package.json
-const DEFAULT_VERSION = 'v2.5.0';
+const DEFAULT_VERSION = 'v2.6.0';
 const VERSION = process.env.CAPISCIO_CORE_VERSION || DEFAULT_VERSION;
 
 export class BinaryManager {

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -204,7 +204,7 @@ describe('CLI Package', () => {
 
   it('should export version', async () => {
     const { version } = await import('../../src/index');
-    expect(version).toBe('2.5.0');
+    expect(version).toBe('2.6.0');
   });
 
   it('should export BinaryManager', async () => {


### PR DESCRIPTION
## Summary

Bump version to 2.6.0 for the v2.6.0 coordinated release.

### Changes
- `package.json` → 2.6.0
- `src/index.ts` exported `version` → 2.6.0
- `src/utils/binary-manager.ts` `DEFAULT_VERSION` → v2.6.0
- `CHANGELOG.md` → add [2.6.0] entry (downloads core v2.6.0)
- `tests/unit/cli.test.ts` → update version assertion
- Rebuilt `dist/`