### PR TITLE
chore: bump version to 2.7.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-05-13
+
+### Changed
+- **CORE VERSION**: Now downloads `capiscio-core` v2.7.0
+
+### Fixed
+- Download timeout and checksum fail-closed (#41)
+- Add `CAPISCIO_REQUIRE_CHECKSUM` fail-closed mode
+- Binary SHA-256 checksum verification after download
+
 ## [2.6.0] - 2026-03-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capiscio",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "The official CapiscIO CLI tool for validating A2A agents",
   "keywords": [
     "a2a",

--- a/src/utils/binary-manager.ts
+++ b/src/utils/binary-manager.ts
@@ -15,7 +15,7 @@ const REPO_OWNER = 'capiscio';
 const REPO_NAME = 'capiscio-core';
 
 // Allow version override via env var or package.json
-const DEFAULT_VERSION = 'v2.6.0';
+const DEFAULT_VERSION = 'v2.7.0';
 const VERSION = process.env.CAPISCIO_CORE_VERSION || DEFAULT_VERSION;
 
 export class BinaryManager {


### PR DESCRIPTION
Version bump 2.6.0 → 2.7.0. Includes CORE_VERSION pin to v2.7.0 in binary-manager.ts.